### PR TITLE
Add babel prepublish task

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "browsers": ["ie >= 11"]
+      }
+    }]
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/lib

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "Podcast plugin for Sanity",
   "main": "lib/index.js",
+  "scripts": {
+    "prepublishOnly": "babel -d lib/ src/"
+  },
   "keywords": [
     "sanity",
     "podcast",
@@ -14,5 +17,9 @@
     "email": "knut.melvaer@gmail.com",
     "url": "https://knutmelvaer.no"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1"
+  }
 }


### PR DESCRIPTION
Sanity compiles "local" plugins automatically (if they're inside the `plugins` folder), but when a module has been published to npm and installed to `node_modules`, we expect it to be precompiled.

This PR adds a prepublish task which runs the source files through babel, which should make sure it works when installed in any Sanity studio.
